### PR TITLE
Add seeded admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ npm run dev
 
 4. Abra [http://localhost:3000](http://localhost:3000) no seu navegador.
 
+## 👥 Usuários Padrão
+
+Após executar `npm run db:seed`, o sistema cria automaticamente dois usuários
+para facilitar o primeiro acesso:
+
+- **Administrador**: `admin@admin.com` / senha `admin`
+- **Demonstração**: `demo@demo.com` / senha `demo`
+
+Utilize a conta de administrador para realizar o primeiro login e cadastrar
+novos usuários reais.
+
 ## 📁 Estrutura do Projeto
 
 ```

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,9 +16,18 @@ async function main() {
     const demoUserEmail = 'demo@demo.com';
     const demoUserPassword = 'demo';
 
+    // Criar usuário administrador
+    const adminUserEmail = 'admin@admin.com';
+    const adminUserPassword = 'admin';
+
     // Verificar se o usuário demo já existe
     const existingDemoUser = await prisma.user.findUnique({
       where: { email: demoUserEmail },
+    });
+
+    // Verificar se o usuário admin já existe
+    const existingAdminUser = await prisma.user.findUnique({
+      where: { email: adminUserEmail },
     });
 
     if (existingDemoUser) {
@@ -44,6 +53,30 @@ async function main() {
         email: demoUser.email,
         name: demoUser.name,
         role: demoUser.role,
+      });
+    }
+
+    if (existingAdminUser) {
+      console.log('✅ Usuário administrador já existe:', adminUserEmail);
+    } else {
+      const hashedPassword = await bcrypt.hash(adminUserPassword, 12);
+
+      const adminUser = await prisma.user.create({
+        data: {
+          name: 'Administrador',
+          email: adminUserEmail,
+          password: hashedPassword,
+          role: 'ADMIN',
+          isActive: true,
+          emailVerified: new Date(),
+        },
+      });
+
+      console.log('✅ Usuário administrador criado:', {
+        id: adminUser.id,
+        email: adminUser.email,
+        name: adminUser.name,
+        role: adminUser.role,
       });
     }
 


### PR DESCRIPTION
## Summary
- seed: create a default admin user besides the demo account
- docs: list default users and credentials

## Testing
- `npm run format`
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f11fbb0208323882398a90c90548d