### PR TITLE
Add team roster view

### DIFF
--- a/src/app/api/leagues/[leagueId]/teams/[teamId]/roster/route.ts
+++ b/src/app/api/leagues/[leagueId]/teams/[teamId]/roster/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { fetchSleeperRosters } from '@/services/sleeperService';
+import { isDemoUser } from '@/data/demoData';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { leagueId: string; teamId: string } },
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const userEmail = session.user.email;
+    if (isDemoUser(userEmail)) {
+      return NextResponse.json({ active: [], reserve: [], taxi: [] });
+    }
+
+    const { leagueId, teamId } = params;
+
+    const league = await prisma.league.findUnique({ where: { id: leagueId } });
+    if (!league || !league.sleeperLeagueId) {
+      return NextResponse.json({ error: 'Liga não encontrada ou sem integração' }, { status: 404 });
+    }
+
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      include: { contracts: true },
+    });
+    if (!team) {
+      return NextResponse.json({ error: 'Time não encontrado' }, { status: 404 });
+    }
+
+    const rosters = await fetchSleeperRosters(league.sleeperLeagueId);
+    const roster = rosters.find(
+      r => r.roster_id.toString() === team.sleeperTeamId || r.owner_id === team.sleeperOwnerId,
+    );
+
+    if (!roster) {
+      return NextResponse.json({ active: [], reserve: [], taxi: [] });
+    }
+
+    const ids = Array.from(
+      new Set([...(roster.players || []), ...(roster.reserve || []), ...(roster.taxi || [])]),
+    );
+
+    const dbPlayers = await prisma.player.findMany({
+      where: { sleeperPlayerId: { in: ids } },
+    });
+    const contracts = await prisma.contract.findMany({ where: { teamId } });
+
+    const mapPlayer = (pid: string) => {
+      const db = dbPlayers.find(p => p.sleeperPlayerId === pid);
+      if (!db) return null;
+      const contract = contracts.find(c => c.playerId === db.id);
+      return {
+        player: {
+          id: db.id,
+          sleeperPlayerId: db.sleeperPlayerId,
+          name: db.name,
+          position: db.position,
+          fantasyPositions: db.fantasyPositions.split(',').filter(s => s),
+          nflTeam: db.team,
+          age: db.age ?? undefined,
+          isActive: db.isActive,
+          createdAt: db.createdAt,
+          updatedAt: db.updatedAt,
+        },
+        contract: contract || null,
+      };
+    };
+
+    const active = (roster.players || [])
+      .map(mapPlayer)
+      .filter((p): p is NonNullable<typeof p> => Boolean(p));
+    const reserve = (roster.reserve || [])
+      .map(mapPlayer)
+      .filter((p): p is NonNullable<typeof p> => Boolean(p));
+    const taxi = (roster.taxi || [])
+      .map(mapPlayer)
+      .filter((p): p is NonNullable<typeof p> => Boolean(p));
+
+    return NextResponse.json({ active, reserve, taxi });
+  } catch (error) {
+    console.error('Erro ao buscar roster:', error);
+    return NextResponse.json({ error: 'Erro interno do servidor' }, { status: 500 });
+  }
+}

--- a/src/app/api/teams/[teamId]/route.ts
+++ b/src/app/api/teams/[teamId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { isDemoUser } from '@/data/demoData';
+
+export async function GET(request: NextRequest, { params }: { params: { teamId: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const userEmail = session.user.email;
+    if (isDemoUser(userEmail)) {
+      return NextResponse.json({ team: null, message: 'Dados demo gerenciados no frontend' });
+    }
+
+    const { teamId } = params;
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+    });
+
+    if (!team) {
+      return NextResponse.json({ error: 'Time não encontrado' }, { status: 404 });
+    }
+
+    return NextResponse.json({ team });
+  } catch (error) {
+    console.error('Erro ao buscar time:', error);
+    return NextResponse.json({ error: 'Erro interno do servidor' }, { status: 500 });
+  }
+}

--- a/src/components/teams/RosterTable.tsx
+++ b/src/components/teams/RosterTable.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { PlayerWithContract } from '@/types';
+import { formatCurrency } from '@/utils/formatUtils';
+import { PencilIcon, TrashIcon, TagIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { Contract } from '@/types';
+
+interface RosterTableProps {
+  active: PlayerWithContract[];
+  reserve: PlayerWithContract[];
+  taxi: PlayerWithContract[];
+  onPlayerAction: (player: PlayerWithContract, action: string) => void;
+}
+
+const positionOrder = ['QB', 'RB', 'WR', 'TE', 'K', 'DL', 'LB', 'DB'];
+
+const sortPlayers = (players: PlayerWithContract[]) =>
+  players.slice().sort((a, b) => {
+    const posA = positionOrder.indexOf(a.player.position);
+    const posB = positionOrder.indexOf(b.player.position);
+    if (posA !== posB) return posA - posB;
+    return a.player.name.localeCompare(b.player.name);
+  });
+
+const calculateDeadMoney = (contract: Contract) => {
+  const remainingSalary = contract.currentSalary * contract.yearsRemaining;
+  return remainingSalary * 0.25;
+};
+
+const Section = ({ title, players }: { title: string; players: PlayerWithContract[] }) => (
+  <>
+    <tr className="bg-gray-100">
+      <th colSpan={7} className="px-6 py-2 text-left text-sm font-semibold text-gray-700">
+        {title}
+      </th>
+    </tr>
+    {sortPlayers(players).map(p => {
+      const deadMoney = p.contract ? calculateDeadMoney(p.contract) : 0;
+      return (
+        <tr key={p.player.id} className="hover:bg-gray-50">
+          <td className="px-6 py-4 whitespace-nowrap">
+            <div className="text-sm font-medium text-gray-900">{p.player.name}</div>
+          </td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{p.player.position}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{p.player.nflTeam}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            {p.contract ? formatCurrency(p.contract.currentSalary) : '-'}
+          </td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">
+            {p.contract ? `${p.contract.yearsRemaining} ano(s)` : '-'}
+          </td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">
+            {p.contract ? p.contract.status : '-'}
+          </td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">
+            {p.contract ? formatCurrency(deadMoney) : '-'}
+          </td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+            {p.contract ? (
+              <div className="flex items-center space-x-2">
+                <button
+                  onClick={() => onPlayerAction(p, 'edit')}
+                  className="text-blue-600 hover:text-blue-900"
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => onPlayerAction(p, 'extend')}
+                  className="text-green-600 hover:text-green-900"
+                >
+                  <ArrowPathIcon className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => onPlayerAction(p, 'tag')}
+                  className="text-purple-600 hover:text-purple-900"
+                >
+                  <TagIcon className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => onPlayerAction(p, 'cut')}
+                  className="text-red-600 hover:text-red-900"
+                >
+                  <TrashIcon className="h-4 w-4" />
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => onPlayerAction(p, 'add')}
+                className="text-blue-600 hover:text-blue-900"
+              >
+                Adicionar Contrato
+              </button>
+            )}
+          </td>
+        </tr>
+      );
+    })}
+  </>
+);
+
+export function RosterTable({ active, reserve, taxi, onPlayerAction }: RosterTableProps) {
+  return (
+    <div className="overflow-x-auto bg-white rounded-lg shadow-sm border border-gray-200">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Jogador
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Posição
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Time NFL
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Salário Atual
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Anos Restantes
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Status
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Dead Money
+            </th>
+            <th className="px-6 py-3" />
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          <Section title="Elenco Ativo" players={active} />
+          {reserve.length > 0 && <Section title="Injured Reserve (IR)" players={reserve} />}
+          {taxi.length > 0 && <Section title="Taxi Squad (TS)" players={taxi} />}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/teams/TeamHeader.tsx
+++ b/src/components/teams/TeamHeader.tsx
@@ -9,7 +9,7 @@ interface TeamHeaderProps {
   team: Team;
   league: League;
   players: PlayerWithContract[];
-  onAddPlayer: () => void;
+  onAddPlayer?: () => void;
 }
 
 export default function TeamHeader({ team, league, players, onAddPlayer }: TeamHeaderProps) {
@@ -49,13 +49,15 @@ export default function TeamHeader({ team, league, players, onAddPlayer }: TeamH
             </p>
           </div>
         </div>
-        <button
-          onClick={onAddPlayer}
-          className="flex items-center bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
-        >
-          <PlusIcon className="h-5 w-5 mr-2" />
-          Adicionar Jogador
-        </button>
+        {onAddPlayer && (
+          <button
+            onClick={onAddPlayer}
+            className="flex items-center bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
+          >
+            <PlusIcon className="h-5 w-5 mr-2" />
+            Adicionar Jogador
+          </button>
+        )}
       </div>
 
       {/* Informações Principais */}

--- a/src/hooks/useRoster.ts
+++ b/src/hooks/useRoster.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from './useAuth';
+import { PlayerWithContract } from '@/types';
+import { getDemoPlayersWithContracts } from '@/data/demoData';
+
+export interface TeamRosterData {
+  active: PlayerWithContract[];
+  reserve: PlayerWithContract[];
+  taxi: PlayerWithContract[];
+}
+
+export function useTeamRoster(leagueId: string, teamId: string) {
+  const { isDemoUser } = useAuth();
+  const [roster, setRoster] = useState<TeamRosterData>({ active: [], reserve: [], taxi: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true);
+        setError(null);
+        if (isDemoUser) {
+          const players = getDemoPlayersWithContracts(teamId);
+          setRoster({ active: players, reserve: [], taxi: [] });
+        } else {
+          const response = await fetch(`/api/leagues/${leagueId}/teams/${teamId}/roster`);
+          if (!response.ok) {
+            throw new Error('Erro ao carregar roster');
+          }
+          const data = await response.json();
+          const parse = (arr: any[]) =>
+            (arr || []).map(p => ({
+              ...p,
+              player: {
+                ...p.player,
+                fantasyPositions: Array.isArray(p.player.fantasyPositions)
+                  ? p.player.fantasyPositions
+                  : p.player.fantasyPositions.split(',').filter((s: string) => s),
+                nflTeam: p.player.nflTeam ?? p.player.team,
+              },
+            }));
+          setRoster({
+            active: parse(data.active),
+            reserve: parse(data.reserve),
+            taxi: parse(data.taxi),
+          });
+        }
+      } catch (err) {
+        console.error('Erro ao carregar roster:', err);
+        setError(err instanceof Error ? err.message : 'Erro desconhecido');
+        setRoster({ active: [], reserve: [], taxi: [] });
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (leagueId && teamId) {
+      load();
+    }
+  }, [isDemoUser, leagueId, teamId]);
+
+  return { roster, loading, error };
+}


### PR DESCRIPTION
## Summary
- create API endpoint to fetch a single team
- expose API to fetch a team's roster using Sleeper player IDs
- add hook `useTeamRoster`
- display roster data in team details page
- add grouped roster table component
- hide Add Player button when action not provided

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68600c103e188323879942ce6337ab67