### PR TITLE
fix: corrige exibição do manager na tabela de times

### DIFF
--- a/prisma/migrations/20250629194750_add_team_abbreviation_and_next_season_dead_money/migration.sql
+++ b/prisma/migrations/20250629194750_add_team_abbreviation_and_next_season_dead_money/migration.sql
@@ -1,0 +1,26 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_teams" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "abbreviation" TEXT,
+    "sleeperOwnerId" TEXT,
+    "ownerDisplayName" TEXT,
+    "sleeperTeamId" TEXT,
+    "currentSalaryCap" REAL NOT NULL DEFAULT 0,
+    "currentDeadMoney" REAL NOT NULL DEFAULT 0,
+    "nextSeasonDeadMoney" REAL NOT NULL DEFAULT 0,
+    "leagueId" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "teams_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "leagues" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "teams_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_teams" ("createdAt", "currentDeadMoney", "currentSalaryCap", "id", "leagueId", "name", "ownerDisplayName", "ownerId", "sleeperOwnerId", "sleeperTeamId", "updatedAt") SELECT "createdAt", "currentDeadMoney", "currentSalaryCap", "id", "leagueId", "name", "ownerDisplayName", "ownerId", "sleeperOwnerId", "sleeperTeamId", "updatedAt" FROM "teams";
+DROP TABLE "teams";
+ALTER TABLE "new_teams" RENAME TO "teams";
+CREATE UNIQUE INDEX "teams_leagueId_sleeperOwnerId_key" ON "teams"("leagueId", "sleeperOwnerId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -150,8 +150,9 @@ enum LeagueStatus {
  * Modelo de time
  */
 model Team {
-  id   String @id @default(cuid())
-  name String
+  id           String @id @default(cuid())
+  name         String
+  abbreviation String?
 
   // Proprietário no Sleeper
   sleeperOwnerId   String?
@@ -161,8 +162,9 @@ model Team {
   sleeperTeamId String?
 
   // Salary Cap
-  currentSalaryCap Float @default(0)
-  currentDeadMoney Float @default(0)
+  currentSalaryCap    Float @default(0)
+  currentDeadMoney    Float @default(0)
+  nextSeasonDeadMoney Float @default(0)
 
   // Relacionamentos
   leagueId String

--- a/src/app/api/leagues/[leagueId]/teams/route.ts
+++ b/src/app/api/leagues/[leagueId]/teams/route.ts
@@ -37,10 +37,10 @@ export async function GET(request: NextRequest, context: { params: { leagueId: s
     const formattedTeams = teams.map(team => ({
       id: team.id,
       name: team.name,
-      abbreviation: team.abbreviation,
+      abbreviation: team.abbreviation || team.name.substring(0, 3).toUpperCase(),
       leagueId: team.leagueId,
       ownerId: team.ownerId,
-      ownerDisplayName: team.owner?.name || team.owner?.email || 'Sem dono',
+      ownerDisplayName: team.ownerDisplayName || team.owner?.name || team.owner?.email || 'Manager não definido',
       currentDeadMoney: team.currentDeadMoney || 0,
       nextSeasonDeadMoney: team.nextSeasonDeadMoney || 0,
       availableCap: 0, // Será calculado no frontend baseado nos contratos

--- a/src/app/api/leagues/sync/route.ts
+++ b/src/app/api/leagues/sync/route.ts
@@ -153,6 +153,8 @@ async function syncLeague(leagueId: string): Promise<SyncResult> {
           where: { id: existingTeam.id },
           data: {
             name: team.name,
+            ownerDisplayName: team.ownerDisplayName,
+            sleeperOwnerId: team.sleeperOwnerId,
             updatedAt: new Date(),
           },
         });
@@ -164,6 +166,8 @@ async function syncLeague(leagueId: string): Promise<SyncResult> {
             leagueId: leagueId,
             ownerId: league.commissionerId, // Por padrão, atribuir ao comissário
             sleeperTeamId: team.sleeperTeamId,
+            ownerDisplayName: team.ownerDisplayName,
+            sleeperOwnerId: team.sleeperOwnerId,
           },
         });
       }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -47,10 +47,15 @@ export interface League {
 export interface Team {
   id: string;
   name: string;
+  abbreviation?: string | null;
   sleeperTeamId?: string | null;
+  sleeperOwnerId?: string | null;
+  ownerDisplayName?: string | null;
   currentSalaryCap?: number | null;
   currentDeadMoney?: number | null;
+  nextSeasonDeadMoney?: number | null;
   leagueId: string;
+  ownerId: string;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
- Adiciona campos abbreviation e nextSeasonDeadMoney ao schema Team
- Corrige API para usar ownerDisplayName do Sleeper
- Atualiza sincronização para preservar dados do manager
- Melhora mensagem de fallback para 'Manager não definido'