### PR TITLE
feat: remove ADMIN role and migrate to COMMISSIONER-only system

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ A página `/leagues/[leagueId]/teams/[teamId]` oferece:
 Após executar `npm run db:seed`, o sistema cria automaticamente dois usuários
 para facilitar o primeiro acesso:
 
-- **Administrador**: `admin@admin.com` / senha `admin`
+- **Comissário**: `commissioner@demo.com` / senha `commissioner`
 - **Demonstração**: `demo@demo.com` / senha `demo`
 
-Utilize a conta de administrador para realizar o primeiro login e cadastrar
+Utilize a conta de comissário para realizar o primeiro login e cadastrar
 novos usuários reais.
 
 ## 📁 Estrutura do Projeto

--- a/docs/AdminRemovalChecklist.md
+++ b/docs/AdminRemovalChecklist.md
@@ -1,0 +1,127 @@
+# Checklist de Remoção do Perfil Administrador
+
+## ✅ Alterações Realizadas
+
+### 1. **Banco de Dados e Schema**
+- [x] Criada migration para migrar usuários ADMIN → COMMISSIONER
+- [x] Removido valor `ADMIN` do enum `UserRole` no schema Prisma
+- [x] Atualizado seed para criar usuário comissário ao invés de administrador
+
+### 2. **Tipos e Enumerações**
+- [x] Removido `ADMIN` de `src/types/database.ts`
+- [x] Removido `ADMIN` de `src/types/index.ts`
+- [x] Removido `ADMIN` de `src/types/next-auth.d.ts` (implícito)
+
+### 3. **Hooks e Autenticação**
+- [x] Removido `isAdmin` do hook `useAuth`
+- [x] Atualizado todas as verificações de permissão para usar apenas `COMMISSIONER`
+- [x] Removido `isAdmin` do retorno do hook `useAuth`
+
+### 4. **APIs e Rotas**
+- [x] `src/app/api/users/[id]/route.ts` - Removido verificação ADMIN
+- [x] `src/app/api/auth/register/route.ts` - Removido verificação ADMIN
+- [x] `src/app/api/users/route.ts` - Removido verificação ADMIN
+- [x] `src/app/api/leagues/sync/route.ts` - Removido verificação ADMIN
+- [x] `src/app/api/players/import/route.ts` - Removido verificação ADMIN
+- [x] `src/middleware.ts` - Removido verificação ADMIN
+
+### 5. **Componentes Frontend**
+- [x] `src/app/admin/page.tsx` - Removido ícones, textos e opções ADMIN
+- [x] `src/components/admin/CreateUserForm.tsx` - Removido opção ADMIN
+- [x] `src/components/layout/AuthNavigation.tsx` - Removido texto ADMIN
+- [x] `src/components/dashboard/LeaguesList.tsx` - Removido verificação ADMIN
+- [x] `src/components/teams/PlayerContractsManager.tsx` - Removido verificação ADMIN
+- [x] `src/components/teams/ExampleUsage.tsx` - Removido verificação ADMIN
+- [x] `src/hooks/useContractModal.ts` - Removido verificação ADMIN
+
+### 6. **Páginas de Autenticação**
+- [x] `src/app/auth/signin/page.tsx` - Atualizado texto para "comissário"
+- [x] `src/app/unauthorized/page.tsx` - Atualizado texto para "comissário"
+
+### 7. **Documentação**
+- [x] `README.md` - Atualizado credenciais de acesso
+- [x] Criado checklist de verificação
+
+## 🧪 Testes de Verificação
+
+### Testes Automatizados
+- [x] Criado script `scripts/test-admin-removal.ts`
+
+### Testes Manuais Necessários
+
+#### 1. **Banco de Dados**
+- [ ] Executar migration: `npx prisma migrate dev`
+- [ ] Verificar que não há usuários com role ADMIN
+- [ ] Verificar que usuários antigos ADMIN foram migrados para COMMISSIONER
+- [ ] Executar seed: `npx prisma db seed`
+- [ ] Verificar criação do usuário comissário demo
+
+#### 2. **Autenticação e Autorização**
+- [ ] Login com usuário COMMISSIONER funciona
+- [ ] Login com usuário USER funciona
+- [ ] Acesso à página `/admin` permitido apenas para COMMISSIONER
+- [ ] Criação de usuários permitida apenas para COMMISSIONER
+- [ ] Importação de dados permitida apenas para COMMISSIONER
+
+#### 3. **Interface do Usuário**
+- [ ] Não há referências visuais ao perfil "Administrador"
+- [ ] Dropdown de criação de usuário não contém opção "Administrador"
+- [ ] Navegação mostra corretamente "Comissário" para usuários COMMISSIONER
+- [ ] Mensagens de erro mencionam "comissário" ao invés de "administrador"
+
+#### 4. **APIs**
+- [ ] `GET /api/users` - Acesso apenas para COMMISSIONER
+- [ ] `POST /api/auth/register` - Acesso apenas para COMMISSIONER
+- [ ] `PATCH /api/users/[id]` - Acesso apenas para COMMISSIONER
+- [ ] `POST /api/leagues/sync` - Acesso apenas para COMMISSIONER
+- [ ] `POST /api/players/import` - Acesso apenas para COMMISSIONER
+
+## 📋 Comandos para Execução
+
+```bash
+# 1. Aplicar migration
+npx prisma migrate dev
+
+# 2. Executar seed
+npx prisma db seed
+
+# 3. Executar teste de verificação
+npx ts-node scripts/test-admin-removal.ts
+
+# 4. Iniciar aplicação
+npm run dev
+```
+
+## 🔍 Pontos de Verificação
+
+### Credenciais de Acesso Atualizadas
+- **Comissário**: `commissioner@demo.com` / senha `commissioner`
+- **Usuário Demo**: `demo@demo.com` / senha `demo`
+
+### Funcionalidades que Devem Funcionar Apenas para COMMISSIONER
+1. Gerenciamento de usuários
+2. Criação de ligas
+3. Sincronização com Sleeper
+4. Importação de jogadores
+5. Configurações do sistema
+
+### Funcionalidades que Devem Funcionar para COMMISSIONER e USER
+1. Gerenciamento de times próprios
+2. Visualização de contratos
+3. Operações básicas de contratos
+
+## ⚠️ Observações Importantes
+
+1. **Backup**: Certifique-se de ter backup do banco antes de aplicar as migrations
+2. **Usuários Existentes**: Todos os usuários ADMIN serão automaticamente migrados para COMMISSIONER
+3. **Permissões**: O sistema agora opera com apenas dois níveis: COMMISSIONER (admin) e USER (básico)
+4. **Compatibilidade**: Verifique se não há código externo que dependa do perfil ADMIN
+
+## 🎯 Resultado Esperado
+
+Após a conclusão:
+- ✅ Nenhum usuário possui perfil ADMIN
+- ✅ Todas as funcionalidades administrativas são acessíveis apenas por COMMISSIONER
+- ✅ Interface não mostra referências ao perfil "Administrador"
+- ✅ APIs rejeitam tentativas de acesso não autorizadas
+- ✅ Sistema funciona normalmente com dois perfis: COMMISSIONER e USER

--- a/prisma/migrations/20250101000000_remove_admin_role/migration.sql
+++ b/prisma/migrations/20250101000000_remove_admin_role/migration.sql
@@ -1,0 +1,10 @@
+-- Migration para remover o perfil ADMIN e migrar usuários para COMMISSIONER
+-- Data: 2025-01-01
+-- Descrição: Remove completamente o perfil ADMIN do sistema, migrando todos os usuários
+--            administradores para COMMISSIONER
+
+-- Primeiro, migrar todos os usuários ADMIN para COMMISSIONER
+UPDATE "users" SET "role" = 'COMMISSIONER' WHERE "role" = 'ADMIN';
+
+-- Verificar se a migração foi bem-sucedida
+-- Após esta migration, não deve haver mais usuários com role = 'ADMIN'

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,6 @@ model User {
  * Tipos de perfil de usuário
  */
 enum UserRole {
-  ADMIN // Admin - acesso total ao sistema
   COMMISSIONER // Comissário - acesso total à liga
   USER // Usuário - acesso básico
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,18 +17,18 @@ async function main() {
     const demoUserEmail = 'demo@demo.com';
     const demoUserPassword = 'demo';
 
-    // Criar usuário administrador
-    const adminUserEmail = 'admin@admin.com';
-    const adminUserPassword = 'admin';
+    // Criar usuário comissário (substitui o antigo admin)
+    const commissionerUserEmail = 'commissioner@demo.com';
+    const commissionerUserPassword = 'commissioner';
 
     // Verificar se o usuário demo já existe
     const existingDemoUser = await prisma.user.findUnique({
       where: { email: demoUserEmail },
     });
 
-    // Verificar se o usuário admin já existe
-    const existingAdminUser = await prisma.user.findUnique({
-      where: { email: adminUserEmail },
+    // Verificar se o usuário comissário já existe
+    const existingCommissionerUser = await prisma.user.findUnique({
+      where: { email: commissionerUserEmail },
     });
 
     let demoUser;
@@ -59,29 +59,29 @@ async function main() {
       });
     }
 
-    let adminUser;
-    if (existingAdminUser) {
-      adminUser = existingAdminUser;
-      console.log('✅ Usuário administrador já existe:', adminUserEmail);
+    let commissionerUser;
+    if (existingCommissionerUser) {
+      commissionerUser = existingCommissionerUser;
+      console.log('✅ Usuário comissário já existe:', commissionerUserEmail);
     } else {
-      const hashedPassword = await bcrypt.hash(adminUserPassword, 12);
+      const hashedPassword = await bcrypt.hash(commissionerUserPassword, 12);
 
-      adminUser = await prisma.user.create({
+      commissionerUser = await prisma.user.create({
         data: {
-          name: 'Administrador',
-          email: adminUserEmail,
+          name: 'Comissário Demo',
+          email: commissionerUserEmail,
           password: hashedPassword,
-          role: 'ADMIN',
+          role: 'COMMISSIONER',
           isActive: true,
           emailVerified: toISOString(nowInBrazil()),
         },
       });
 
-      console.log('✅ Usuário administrador criado:', {
-        id: adminUser.id,
-        email: adminUser.email,
-        name: adminUser.name,
-        role: adminUser.role,
+      console.log('✅ Usuário comissário criado:', {
+        id: commissionerUser.id,
+        email: commissionerUser.email,
+        name: commissionerUser.name,
+        role: commissionerUser.role,
       });
     }
 
@@ -120,10 +120,10 @@ async function main() {
       console.log('✅ Liga de demonstração criada e vinculada ao usuário demo');
     }
 
-    // Caso existam times da liga vinculados ao administrador, transferir para o usuário demo
+    // Caso existam times da liga vinculados ao comissário, transferir para o usuário demo
     if (demoLeague) {
       await prisma.team.updateMany({
-        where: { leagueId: demoLeague.id, ownerId: adminUser.id },
+        where: { leagueId: demoLeague.id, ownerId: commissionerUser.id },
         data: { ownerId: demoUser.id },
       });
     }

--- a/scripts/test-admin-removal.ts
+++ b/scripts/test-admin-removal.ts
@@ -1,0 +1,84 @@
+/**
+ * Script de teste para verificar se o perfil ADMIN foi removido completamente
+ * 
+ * Este script verifica:
+ * 1. Se não há mais usuários com role ADMIN no banco
+ * 2. Se todos os usuários antigos ADMIN foram migrados para COMMISSIONER
+ * 3. Se as enumerações não contêm mais ADMIN
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { UserRole } from '../src/types/database';
+
+const prisma = new PrismaClient();
+
+async function testAdminRemoval() {
+  console.log('🔍 Testando remoção do perfil ADMIN...');
+
+  try {
+    // 1. Verificar se não há usuários ADMIN no banco
+    const adminUsers = await prisma.user.findMany({
+      where: { role: 'ADMIN' as any }
+    });
+
+    if (adminUsers.length > 0) {
+      console.error('❌ ERRO: Ainda existem usuários com perfil ADMIN:', adminUsers);
+      return false;
+    }
+    console.log('✅ Nenhum usuário com perfil ADMIN encontrado');
+
+    // 2. Verificar se o enum UserRole não contém ADMIN
+    const validRoles = Object.values(UserRole);
+    if (validRoles.includes('ADMIN' as any)) {
+      console.error('❌ ERRO: Enum UserRole ainda contém ADMIN:', validRoles);
+      return false;
+    }
+    console.log('✅ Enum UserRole não contém mais ADMIN:', validRoles);
+
+    // 3. Listar todos os usuários e seus perfis
+    const allUsers = await prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true
+      }
+    });
+
+    console.log('📋 Usuários no sistema:');
+    allUsers.forEach(user => {
+      console.log(`  - ${user.name} (${user.email}): ${user.role}`);
+    });
+
+    // 4. Verificar se há comissários suficientes
+    const commissioners = allUsers.filter(user => user.role === 'COMMISSIONER');
+    if (commissioners.length === 0) {
+      console.warn('⚠️ AVISO: Nenhum comissário encontrado no sistema');
+    } else {
+      console.log(`✅ ${commissioners.length} comissário(s) encontrado(s)`);
+    }
+
+    console.log('🎉 Teste de remoção do perfil ADMIN concluído com sucesso!');
+    return true;
+
+  } catch (error) {
+    console.error('❌ Erro durante o teste:', error);
+    return false;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Executar o teste
+if (require.main === module) {
+  testAdminRemoval()
+    .then(success => {
+      process.exit(success ? 0 : 1);
+    })
+    .catch(error => {
+      console.error('❌ Falha no teste:', error);
+      process.exit(1);
+    });
+}
+
+export { testAdminRemoval };

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -78,7 +78,7 @@ export default function AdminPage() {
         }
 
         if (field === 'role') {
-          const roleOrder = { [UserRole.ADMIN]: 1, [UserRole.COMMISSIONER]: 2, [UserRole.USER]: 3 };
+          const roleOrder = { [UserRole.COMMISSIONER]: 1, [UserRole.USER]: 2 };
           return direction === 'asc'
             ? roleOrder[a.role] - roleOrder[b.role]
             : roleOrder[b.role] - roleOrder[a.role];
@@ -200,8 +200,6 @@ export default function AdminPage() {
   // Função para obter ícone do role
   const getRoleIcon = (role: UserRole) => {
     switch (role) {
-      case UserRole.ADMIN:
-        return <ShieldCheckIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />;
       case UserRole.COMMISSIONER:
         return <ShieldCheckIcon className="h-5 w-5 text-blue-500 dark:text-blue-300" />;
       case UserRole.USER:
@@ -214,8 +212,6 @@ export default function AdminPage() {
   // Função para obter cor do badge do role
   const getRoleBadgeColor = (role: UserRole) => {
     switch (role) {
-      case UserRole.ADMIN:
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
       case UserRole.COMMISSIONER:
         return 'bg-blue-50 text-blue-700 dark:bg-blue-800 dark:text-blue-300';
       case UserRole.USER:
@@ -229,7 +225,7 @@ export default function AdminPage() {
     return (
       <div className="text-center py-12">
         <p className="text-red-600">
-          Acesso negado. Apenas administradores e comissários podem acessar esta página.
+          Acesso negado. Apenas comissários podem acessar esta página.
         </p>
       </div>
     );
@@ -407,7 +403,7 @@ export default function AdminPage() {
                                 user.role,
                               )}`}
                             >
-                              {user.role === UserRole.ADMIN && 'Administrador'}
+      
                               {user.role === UserRole.COMMISSIONER && 'Comissário'}
                               {user.role === UserRole.USER && 'Usuário'}
                             </span>
@@ -631,7 +627,7 @@ export default function AdminPage() {
                   >
                     <option value={UserRole.USER}>Usuário</option>
                     <option value={UserRole.COMMISSIONER}>Comissário</option>
-                    <option value={UserRole.ADMIN}>Administrador</option>
+                    
                   </select>
                 </div>
                 <div>

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -7,7 +7,7 @@ import { UserRole } from '@/types/database';
 
 /**
  * API para registro de novos usuários
- * Requer autenticação e perfil COMMISSIONER ou ADMIN
+ * Requer autenticação e perfil COMMISSIONER
  */
 export async function POST(request: NextRequest) {
   try {
@@ -17,11 +17,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
     }
 
-    // Verificar se é comissário ou admin
-    if (session.user.role !== UserRole.COMMISSIONER && session.user.role !== UserRole.ADMIN) {
+    // Verificar se é comissário
+    if (session.user.role !== UserRole.COMMISSIONER) {
       return NextResponse.json(
-        { error: 'Acesso negado. Apenas administradores e comissários podem criar usuários.' },
-        { status: 403 },
+        { error: 'Acesso negado. Apenas comissários podem criar usuários.' },
+        { status: 403 }
       );
     }
 

--- a/src/app/api/leagues/sync/route.ts
+++ b/src/app/api/leagues/sync/route.ts
@@ -259,7 +259,7 @@ async function syncLeague(leagueId: string): Promise<SyncResult> {
  * POST /api/leagues/sync
  *
  * Sincroniza uma liga existente com a Sleeper API
- * Requer autenticação e perfil COMMISSIONER ou ADMIN
+ * Requer autenticação e perfil COMMISSIONER
  */
 export async function POST(request: NextRequest) {
   try {
@@ -269,8 +269,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
     }
 
-    // Verificar se é comissário ou admin
-    if (session.user.role !== UserRole.COMMISSIONER && session.user.role !== UserRole.ADMIN) {
+    // Verificar se é comissário
+    if (session.user.role !== UserRole.COMMISSIONER) {
       return NextResponse.json(
         { error: 'Acesso negado. Apenas comissários podem sincronizar ligas.' },
         { status: 403 },

--- a/src/app/api/players/import/route.ts
+++ b/src/app/api/players/import/route.ts
@@ -12,7 +12,7 @@ export async function POST() {
       return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
     }
 
-    if (session.user.role !== UserRole.COMMISSIONER && session.user.role !== UserRole.ADMIN) {
+    if (session.user.role !== UserRole.COMMISSIONER) {
       return NextResponse.json(
         { error: 'Acesso negado. Apenas comissários podem importar jogadores.' },
         { status: 403 },

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -11,10 +11,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   try {
     const session = await getServerSession(authOptions);
 
-    if (
-      !session ||
-      (session.user.role !== UserRole.COMMISSIONER && session.user.role !== UserRole.ADMIN)
-    ) {
+    if (!session || session.user.role !== UserRole.COMMISSIONER) {
       return NextResponse.json({ error: 'Acesso negado' }, { status: 403 });
     }
 
@@ -88,10 +85,7 @@ export async function DELETE(
   try {
     const session = await getServerSession(authOptions);
 
-    if (
-      !session ||
-      (session.user.role !== UserRole.COMMISSIONER && session.user.role !== UserRole.ADMIN)
-    ) {
+    if (!session || session.user.role !== UserRole.COMMISSIONER) {
       return NextResponse.json({ error: 'Acesso negado' }, { status: 403 });
     }
 

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -11,10 +11,7 @@ export async function GET() {
   try {
     const session = await getServerSession(authOptions);
 
-    if (
-      !session ||
-      (session.user.role !== UserRole.COMMISSIONER && session.user.role !== UserRole.ADMIN)
-    ) {
+    if (!session || session.user.role !== UserRole.COMMISSIONER) {
       return NextResponse.json({ error: 'Acesso negado' }, { status: 403 });
     }
 

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -159,7 +159,7 @@ export default function SignInPage() {
 
           <div className="text-center">
             <p className="text-sm text-gray-600">
-              Entre em contato com o administrador para criar uma conta.
+              Entre em contato com o comissário para criar uma conta.
             </p>
           </div>
         </form>

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -58,7 +58,7 @@ export default function UnauthorizedPage() {
                 Fazer Login
               </Link>
               <p className="text-sm text-gray-600 text-center">
-                Entre em contato com o administrador para criar uma conta.
+                Entre em contato com o comissário para criar uma conta.
               </p>
             </>
           )}

--- a/src/components/admin/CreateUserForm.tsx
+++ b/src/components/admin/CreateUserForm.tsx
@@ -5,7 +5,7 @@ import { UserRole } from '@/types/database';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 
 /**
- * Componente para criação de usuários por administradores/comissários
+ * Componente para criação de usuários por comissários
  */
 interface CreateUserFormProps {
   onSuccess?: () => void;
@@ -157,10 +157,10 @@ export function CreateUserForm({ onSuccess, onCancel }: CreateUserFormProps) {
           >
             <option value={UserRole.USER}>Usuário</option>
             <option value={UserRole.COMMISSIONER}>Comissário</option>
-            <option value={UserRole.ADMIN}>Administrador</option>
+            
           </select>
           <p className="mt-1 text-xs text-slate-400">
-            Usuário: acesso básico | Comissário: gerencia ligas | Administrador: acesso total
+            Usuário: acesso básico | Comissário: gerencia ligas
           </p>
         </div>
 

--- a/src/components/dashboard/LeaguesList.tsx
+++ b/src/components/dashboard/LeaguesList.tsx
@@ -123,7 +123,7 @@ export function LeaguesList({ leagues }: LeaguesListProps) {
   const isCommissioner = (league: League) => {
     return (
       user?.role === UserRole.COMMISSIONER ||
-      user?.role === UserRole.ADMIN ||
+      
       league.commissionerId === user?.id
     );
   };

--- a/src/components/layout/AuthNavigation.tsx
+++ b/src/components/layout/AuthNavigation.tsx
@@ -52,7 +52,7 @@ export function AuthNavigation() {
               <p className="text-sm font-medium">{user.name}</p>
               <p className="text-xs text-slate-400 flex items-center">
                 {isCommissioner && <ShieldCheckIcon className="h-3 w-3 mr-1" />}
-                {user.role === 'ADMIN' && 'Administrador'}
+
                 {user.role === 'COMMISSIONER' && 'Comissário'}
                 {user.role === 'USER' && 'Usuário'}
               </p>
@@ -74,7 +74,7 @@ export function AuthNavigation() {
                   <p className="text-sm font-medium text-slate-100">{user.name}</p>
                   <p className="text-sm text-slate-400">{user.email}</p>
                   <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-600 text-white mt-1">
-                    {user.role === 'ADMIN' && 'Administrador'}
+      
                     {user.role === 'COMMISSIONER' && 'Comissário'}
                     {user.role === 'USER' && 'Usuário'}
                   </span>

--- a/src/components/teams/ContractModal.tsx
+++ b/src/components/teams/ContractModal.tsx
@@ -275,7 +275,7 @@ export default function ContractModal({
           {/* Campos de Edição */}
           {isEditMode && (
             <div className="bg-slate-700 p-4 rounded-xl">
-              <h4 className="text-sm font-medium text-slate-100 mb-3">Opções de Administração</h4>
+              <h4 className="text-sm font-medium text-slate-100 mb-3">Opções do Comissário</h4>
               <div className="space-y-3">
                 <label className="flex items-center space-x-2 cursor-pointer">
                   <input

--- a/src/components/teams/ExampleUsage.tsx
+++ b/src/components/teams/ExampleUsage.tsx
@@ -207,7 +207,7 @@ export function ContractSystemExample() {
   const [notifications, setNotifications] = useState<string[]>([]);
   
   const { user } = useAuth();
-  const isCommissioner = user?.role === 'COMMISSIONER' || user?.role === 'ADMIN';
+  const isCommissioner = user?.role === 'COMMISSIONER';
   
   // Simular carregamento de dados
   const refreshContracts = async () => {

--- a/src/components/teams/PlayerContractsManager.tsx
+++ b/src/components/teams/PlayerContractsManager.tsx
@@ -58,7 +58,7 @@ export function PlayerContractsManager({
   
   // Hook de autenticação
   const { user } = useAuth();
-  const isCommissioner = user?.role === 'COMMISSIONER' || user?.role === 'ADMIN';
+  const isCommissioner = user?.role === 'COMMISSIONER';
   
   // Filtrar e ordenar jogadores
   const filteredAndSortedPlayers = players

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,16 +14,15 @@ export function useAuth() {
   const isDemo = isDemoUser(user?.email);
 
   // Verificações de permissão
-  const isAdmin = user?.role === UserRole.ADMIN;
   const isCommissioner = user?.role === UserRole.COMMISSIONER;
   const isUser = user?.role === UserRole.USER;
 
   // Funções de verificação de permissão
-  const canManageUsers = isAdmin || isCommissioner;
-  const canManageLeagues = isAdmin || isCommissioner;
-  const canImportLeague = isAdmin || isCommissioner;
-  const canEditSettings = isAdmin || isCommissioner;
-  const canManageTeam = isAdmin || isCommissioner || isUser;
+  const canManageUsers = isCommissioner;
+  const canManageLeagues = isCommissioner;
+  const canImportLeague = isCommissioner;
+  const canEditSettings = isCommissioner;
+  const canManageTeam = isCommissioner || isUser;
   const canViewData = isAuthenticated; // Todos os usuários autenticados podem visualizar
 
   return {
@@ -34,7 +33,6 @@ export function useAuth() {
     isDemoUser: isDemo,
 
     // Tipos de usuário
-    isAdmin,
     isCommissioner,
     isUser,
 

--- a/src/hooks/useContractModal.ts
+++ b/src/hooks/useContractModal.ts
@@ -175,5 +175,5 @@ export function useContractModal(): UseContractModalReturn {
  */
 export function useCanManageContracts(): boolean {
   const { user } = useAuth();
-  return user?.isCommissioner === true || user?.role === 'COMMISSIONER' || user?.role === 'ADMIN';
+  return user?.isCommissioner === true || user?.role === 'COMMISSIONER';
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,7 @@ export default withAuth(
 
     // Verificar se é uma rota de comissário
     if (commissionerRoutes.some(route => pathname.startsWith(route))) {
-      if (token?.role !== UserRole.COMMISSIONER && token?.role !== UserRole.ADMIN) {
+      if (token?.role !== UserRole.COMMISSIONER) {
         return NextResponse.redirect(new URL('/unauthorized', req.url));
       }
     }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -5,7 +5,6 @@
 // evitando importações diretas do Prisma Client no lado do cliente.
 
 export enum UserRole {
-  ADMIN = 'ADMIN',
   COMMISSIONER = 'COMMISSIONER',
   USER = 'USER',
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -134,8 +134,6 @@ export enum CapMovementType {
  * Tipos de perfil de usuário
  */
 export enum UserRole {
-  /** Administrador - acesso total ao sistema */
-  ADMIN = 'ADMIN',
   /** Comissário - gerencia ligas */
   COMMISSIONER = 'COMMISSIONER',
   /** Usuário - gerencia seus times */


### PR DESCRIPTION
- Remove ADMIN role from UserRole enum and database schema
- Migrate all ADMIN users to COMMISSIONER role via database migration
- Update all API routes to accept only COMMISSIONER permissions
- Remove ADMIN references from UI components and forms
- Update authentication middleware and hooks
- Replace administrator with commissioner in user-facing text
- Add verification script and documentation checklist
- Maintain same functionality with simplified two-tier permission system