### PR TITLE
fix: corrige persistência do deadMoneyConfig em ligas

### DIFF
--- a/src/app/api/leagues/[leagueId]/route.ts
+++ b/src/app/api/leagues/[leagueId]/route.ts
@@ -173,7 +173,7 @@ export async function PUT(
         ...(minimumSalary && { minimumSalary }),
         ...(annualIncreasePercentage !== undefined && { annualIncreasePercentage }),
         ...(seasonTurnoverDate && { seasonTurnoverDate }),
-        ...(deadMoneyConfig && { deadMoneyConfig: JSON.stringify(deadMoneyConfig) }),
+        ...(deadMoneyConfig !== undefined && { deadMoneyConfig: JSON.stringify(deadMoneyConfig) }),
       },
       include: {
         teams: {

--- a/src/components/leagues/LeagueModal.tsx
+++ b/src/components/leagues/LeagueModal.tsx
@@ -175,6 +175,7 @@ export default function LeagueModal({ isOpen, onClose, league }: LeagueModalProp
             annualIncreasePercentage: formData.annualIncreasePercentage,
             minimumSalary: formData.minimumSalary,
             seasonTurnoverDate: formData.seasonTurnoverDate,
+            deadMoneyConfig: formData.deadMoneyConfig,
           }),
         });
 
@@ -244,6 +245,7 @@ export default function LeagueModal({ isOpen, onClose, league }: LeagueModalProp
             annualIncreasePercentage: formData.annualIncreasePercentage,
             minimumSalary: formData.minimumSalary,
             seasonTurnoverDate: formData.seasonTurnoverDate,
+            deadMoneyConfig: formData.deadMoneyConfig,
           }),
         });
 

--- a/src/hooks/useLeagues.ts
+++ b/src/hooks/useLeagues.ts
@@ -54,9 +54,23 @@ export function useLeagues() {
               },
             };
 
+            // Parse do deadMoneyConfig se existir
+            let deadMoneyConfig;
+            if (l.deadMoneyConfig) {
+              try {
+                deadMoneyConfig = typeof l.deadMoneyConfig === 'string' 
+                  ? JSON.parse(l.deadMoneyConfig) 
+                  : l.deadMoneyConfig;
+              } catch (error) {
+                console.warn('Erro ao fazer parse do deadMoneyConfig:', error);
+                deadMoneyConfig = undefined;
+              }
+            }
+
             return {
               ...l,
               settings,
+              deadMoneyConfig,
             } as League;
           });
 


### PR DESCRIPTION
- Adiciona deadMoneyConfig nas requisições de criação/edição no LeagueModal
- Inclui deadMoneyConfig na API de importação de ligas
- Corrige mapeamento do deadMoneyConfig no hook useLeagues
- Garante persistência correta da configuração no banco de dados
- Resolve bug onde deadMoneyConfig não era salvo/recuperado adequadamente